### PR TITLE
chore: :see_no_evil: add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 /export
+node_modules


### PR DESCRIPTION
Small improvement to .gitignore to skip node_modules.
Or is the reason for not inclucing it, that users have to think about what to they prefer to include?